### PR TITLE
Add tournament CRUD module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { TournamentModule } from './tournament/tournament.module';
 
 @Module({
-  imports: [],
+  imports: [TournamentModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,6 @@
 import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
+import * as schema from './db/schema';
 
 const sql = neon(process.env.DATABASE_URL!);
-const db = drizzle({ client: sql });
+export const db = drizzle(sql, { schema });

--- a/backend/src/tournament/dto/create-tournament.dto.ts
+++ b/backend/src/tournament/dto/create-tournament.dto.ts
@@ -1,0 +1,8 @@
+export class CreateTournamentDto {
+  name: string;
+  status?: string;
+  registration_deadline?: string;
+  rating_cutoff?: string;
+  date?: string;
+  time?: string;
+}

--- a/backend/src/tournament/dto/update-tournament.dto.ts
+++ b/backend/src/tournament/dto/update-tournament.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTournamentDto } from './create-tournament.dto';
+
+export class UpdateTournamentDto extends PartialType(CreateTournamentDto) {}

--- a/backend/src/tournament/tournament.controller.ts
+++ b/backend/src/tournament/tournament.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { TournamentService } from './tournament.service';
+import { CreateTournamentDto } from './dto/create-tournament.dto';
+import { UpdateTournamentDto } from './dto/update-tournament.dto';
+
+@Controller('tournament')
+export class TournamentController {
+  constructor(private readonly tournamentService: TournamentService) {}
+
+  @Post()
+  create(@Body() dto: CreateTournamentDto) {
+    return this.tournamentService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.tournamentService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.tournamentService.findOne(Number(id));
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateTournamentDto) {
+    return this.tournamentService.update(Number(id), dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.tournamentService.remove(Number(id));
+  }
+}

--- a/backend/src/tournament/tournament.module.ts
+++ b/backend/src/tournament/tournament.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TournamentService } from './tournament.service';
+import { TournamentController } from './tournament.controller';
+
+@Module({
+  controllers: [TournamentController],
+  providers: [TournamentService],
+})
+export class TournamentModule {}

--- a/backend/src/tournament/tournament.service.ts
+++ b/backend/src/tournament/tournament.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { db } from '../index';
+import { tournament } from '../db/schema';
+import { CreateTournamentDto } from './dto/create-tournament.dto';
+import { UpdateTournamentDto } from './dto/update-tournament.dto';
+
+@Injectable()
+export class TournamentService {
+  async create(dto: CreateTournamentDto) {
+    const [created] = await db.insert(tournament).values(dto).returning();
+    return created;
+  }
+
+  findAll() {
+    return db.select().from(tournament);
+  }
+
+  async findOne(id: number) {
+    const rows = await db
+      .select()
+      .from(tournament)
+      .where(eq(tournament.id, id));
+    return rows[0];
+  }
+
+  async update(id: number, dto: UpdateTournamentDto) {
+    const [updated] = await db
+      .update(tournament)
+      .set(dto)
+      .where(eq(tournament.id, id))
+      .returning();
+    return updated;
+  }
+
+  async remove(id: number) {
+    const [deleted] = await db
+      .delete(tournament)
+      .where(eq(tournament.id, id))
+      .returning();
+    return deleted;
+  }
+}


### PR DESCRIPTION
## Summary
- export the DB instance from `index.ts`
- wire up `TournamentModule` in the app
- implement CRUD logic for tournaments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c8f7e4a1883319b5a228f901b0504